### PR TITLE
Date Picker Inputs in Add Contact panel

### DIFF
--- a/src/components/ManageContacts/AddAndModifyPanel/AddContact.tsx
+++ b/src/components/ManageContacts/AddAndModifyPanel/AddContact.tsx
@@ -1,6 +1,7 @@
 import {
   RuxContainer,
   RuxDatetime,
+  RuxInput,
   RuxOption,
   RuxSelect,
   RuxTable,
@@ -17,6 +18,8 @@ import {
   RuxInputCustomEvent,
 } from '@astrouxds/astro-web-components/dist/types/components';
 import type { DefaultOptions } from 'Types';
+import { addCommaToEquipString } from 'utils/utils';
+import { formatReadableTime } from 'utils/date';
 
 type PropTypes = {
   options: DefaultOptions;
@@ -123,27 +126,25 @@ const AddContactForm = ({ options, values, setValues }: PropTypes) => {
         <div className='start-stop-time'>
           <div>Pre Pass Start:</div>
           {values.pass !== -1 && options.passes ? (
-            <RuxDatetime
-              date={options?.passes[values.pass].aos}
-              hour='2-digit'
-              minute='2-digit'
-              second='2-digit'
+            <RuxInput
+              value={formatReadableTime(options?.passes[values.pass].aos)}
+              type='time'
+              disabled
             />
           ) : (
-            <span>---</span>
+            <RuxInput type='time' disabled />
           )}
         </div>
         <div className='start-stop-time'>
           <div>Post Pass Stop: </div>
           {values.pass !== -1 && options.passes ? (
-            <RuxDatetime
-              date={options?.passes[values.pass].los}
-              hour='2-digit'
-              minute='2-digit'
-              second='2-digit'
+            <RuxInput
+              value={formatReadableTime(options?.passes[values.pass].los)}
+              type='time'
+              disabled
             />
           ) : (
-            <span>---</span>
+            <RuxInput type='time' disabled />
           )}
         </div>
       </section>
@@ -170,7 +171,7 @@ const AddContactForm = ({ options, values, setValues }: PropTypes) => {
               <RuxOption key={label} label={label} value={value} />
             ))}
           </RuxSelect>
-          <p>{values.equipment}</p>
+          <p>{addCommaToEquipString(values.equipment)}</p>
 
           <EquipmentIcons equipmentString={values.equipment} />
         </RuxContainer>

--- a/src/components/ManageContacts/AddAndModifyPanel/ModifyContact.tsx
+++ b/src/components/ManageContacts/AddAndModifyPanel/ModifyContact.tsx
@@ -20,6 +20,7 @@ import {
 } from '@astrouxds/astro-web-components/dist/types/components';
 import type { DefaultOptions } from 'Types';
 import { capitalize } from 'utils/labels';
+import { addCommaToEquipString } from 'utils/utils';
 
 type PropTypes = {
   options: DefaultOptions;
@@ -172,7 +173,7 @@ const ModifyContactForm = ({ options, values, setValues }: PropTypes) => {
               <RuxOption key={label} label={label} value={value} />
             ))}
           </RuxSelect>
-          <p>{values.equipment}</p>
+          <p>{addCommaToEquipString(values.equipment)}</p>
 
           <EquipmentIcons equipmentString={values.equipment} />
         </RuxContainer>

--- a/src/components/ManageContacts/ContactDetails/ContactDetails.tsx
+++ b/src/components/ManageContacts/ContactDetails/ContactDetails.tsx
@@ -15,6 +15,7 @@ import SmallReadOnlyInput from 'common/SmallReadOnlyInput/SmallReadOnlyInput';
 import { Actions } from 'Types';
 import EquipmentIcons from 'common/EquipmentIcons/EquipmentIcons';
 import './ContactDetails.css';
+import { addCommaToEquipString } from 'utils/utils';
 
 type PropTypes = {
   handleAction: (action?: Actions) => void;
@@ -89,7 +90,7 @@ const ContactDetails = ({ handleAction }: PropTypes) => {
             <RuxContainer>
               <div slot='header'>Equipment String</div>
               <SmallReadOnlyInput label='Configuration' value={config} />
-              <label>{contactEquipment}</label>
+              <label>{addCommaToEquipString(contactEquipment)}</label>
               <EquipmentIcons equipmentString={contactEquipment} />
             </RuxContainer>
             <RuxTextarea disabled label='Notes' value={contactDetail} />

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -19,3 +19,15 @@ export const setDurationMins = (start: number, end: number) => {
   const diffMins = Math.abs((start - end) / (1000 * 60));
   return `${diffMins}:00`;
 };
+
+export function formatReadableTime(timestamp: Date | number | string) {
+  // assumes timestamp is a UTC Epoch
+  const time = new Date(timestamp);
+
+  return new Date(time).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -13,3 +13,8 @@ export const addToast = (
     closeAfter: closeAfter,
   });
 };
+
+export const addCommaToEquipString = (equipment: string) => {
+  const equipmentStr = equipment.replace(/(\w+)/g, '$1,');
+  return equipmentStr.replace(/,$/, '');
+};


### PR DESCRIPTION
- Update Pre Pass Start and Post Pass Start to time inputs 
Note: these are disabled because they are automatically the aol/los time that you select from the Passes table, which is probably why it was set up the way it was
- Add commas to separate equipment strings
https://rocketcom.atlassian.net/browse/DEMO-261