### PR TITLE
Selected Time Region overflow/Table header wrapping

### DIFF
--- a/src/components/ContactsList/ContactsListColumns.tsx
+++ b/src/components/ContactsList/ContactsListColumns.tsx
@@ -36,12 +36,12 @@ export const columnDefs = [
   columnHelper.accessor('contactPriority', {
     header: 'Priority',
     cell: (info) => info.getValue(),
-    style: { minWidth: 50 },
+    style: { minWidth: 70 },
   }),
   columnHelper.accessor('contactStatus', {
     header: 'Status',
     cell: (info) => <RuxStatus status={info.getValue()} />,
-    style: { minWidth: 50, justifyContent: 'center' },
+    style: { minWidth: 55, justifyContent: 'center' },
     sortingFn: sortStatus,
   }),
   columnHelper.accessor('contactName', {
@@ -50,7 +50,7 @@ export const columnDefs = [
   }),
   columnHelper.accessor('contactGround', {
     header: 'Ground Station',
-    style: { minWidth: 145 },
+    style: { minWidth: 125 },
   }),
   columnHelper.accessor('contactREV', {
     header: 'REV',
@@ -58,7 +58,7 @@ export const columnDefs = [
   }),
   columnHelper.accessor('contactEquipment', {
     header: 'Equipment String',
-    style: { minWidth: 424, flex: 4 },
+    style: { minWidth: 410, flex: 1 },
   }),
   columnHelper.accessor('contactState', {
     header: 'State',

--- a/src/components/ContactsTimeline/ContactsTimeline.css
+++ b/src/components/ContactsTimeline/ContactsTimeline.css
@@ -25,6 +25,10 @@ rux-time-region::part(container) {
   cursor: pointer;
 }
 
+rux-time-region[selected] {
+  z-index: 1;
+}
+
 .timeline-wrapper {
   position: relative;
   overflow: hidden;

--- a/src/components/ContactsTimeline/ContactsTimeline.css
+++ b/src/components/ContactsTimeline/ContactsTimeline.css
@@ -25,11 +25,6 @@ rux-time-region::part(container) {
   cursor: pointer;
 }
 
-rux-time-region[selected] {
-  position: relative;
-  z-index: 2;
-}
-
 .timeline-wrapper {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
- Prevent selected time region from overflowing in to Ground Station name column. The z-index being set to 2 was just enough to make it take priority over the name column. In switching it to 1, it will still have the selected region take priority over overlapping time regions, but avoid it covering the names to the left. 
https://rocketcom.atlassian.net/browse/DEMO-259

- Prevent table header from wrapping when panel is open 
https://rocketcom.atlassian.net/browse/DEMO-258